### PR TITLE
Fix bug in 'legged_unitree_hw.launch'

### DIFF
--- a/legged_examples/legged_unitree/legged_unitree_hw/launch/legged_unitree_hw.launch
+++ b/legged_examples/legged_unitree/legged_unitree_hw/launch/legged_unitree_hw.launch
@@ -5,7 +5,7 @@
        robot_type:=$(arg robot_type)
     "/>
     <node name="generate_urdf" pkg="legged_common" type="generate_urdf.sh" output="screen"
-          args="legged_robot_description $(arg robot_type)"/>
+          args="$(find legged_unitree_description)/urdf/robot.xacro $(arg robot_type)"/>
 
     <rosparam file="$(find legged_unitree_hw)/config/$(arg robot_type).yaml" command="load"/>
 


### PR DESCRIPTION
For error: "No such file or directory: legged_robot_description [Errno 2] No such file or directory: 'legged_robot_description'"

执行

```roslaunch legged_unitree_hw legged_unitree_hw.launch```

启动硬件时，会报这个错误。

这应该是个笔误，因为启动仿真时不会报错。:smile: